### PR TITLE
Moving AST docs to build step, adding path, file and ignores config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+node_modules
 jspm_packages/
 
 # TypeScript v1 declaration files

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,69 +1,117 @@
 import { extendEnvironment, task } from "@nomiclabs/buidler/config";
+import { BuidlerPluginError, lazyObject } from "@nomiclabs/buidler/plugins";
+import { SOLC_INPUT_FILENAME, SOLC_OUTPUT_FILENAME } from "@nomiclabs/buidler/internal/constants";
+
 import fs from "fs";
 import path from "path";
 
 import { extractASTInformation } from "./helpers";
 
+export class ASTDocsBuidlerEnvironment {
+  constructor(
+    public readonly path: string = undefined,
+    public readonly file: string = "ast-docs.json",
+    public readonly ignores: string = ""
+  ) { }
+}
+
+declare module "@nomiclabs/buidler/types" {
+  export interface BuidlerRuntimeEnvironment {
+    astdocs: ASTDocsBuidlerEnvironment;
+  }
+
+  export interface BuidlerConfig {
+    astdocs?: {
+      path?: string;
+      file?: string;
+      ignores?: string;
+    };
+  }
+}
+
 // Everything in a plugin must happen inside an exported function
 extendEnvironment((env: any) => {
   // Force env to generate AST
   env.config.solc.outputSelection = { "*": { "*": ["*"], "": ["*"] } };
+
+  env.astdocs = lazyObject(() => {
+    if (env.config.astdocs) {
+      return new ASTDocsBuidlerEnvironment(
+        env.config.astdocs.path,
+        env.config.astdocs.file,
+        env.config.astdocs.ignores
+      );
+    }
+    return new ASTDocsBuidlerEnvironment();
+  });
 });
 
-// Add a new task
-task("build:ast-doc", "Generate document representation (in JSON) from AST")
-  .addParam(
-    "astDocDir",
-    "Directory to output document representation extracted from the AST"
-  )
-  .setAction(async (taskArguments, bre) => {
-    const { astDocDir } = taskArguments;
+task("compile", "compilation step", async (taskArguments, bre, runSuper) => {
+  await runSuper();
 
-    const cachePath = bre.config.paths.cache;
-    const solcInput = require(path.resolve(cachePath, "solc-input.json"));
-    const solcOutput = require(path.resolve(cachePath, "solc-output.json"));
+  // now do AST processing
+  createAST({ bre });
+});
 
-    const contractInformation = extractASTInformation(
-      solcInput,
-      solcOutput,
-      "contract"
-    );
-    const interfaceInformation = extractASTInformation(
-      solcInput,
-      solcOutput,
-      "interface"
-    );
-    const libraryInformation = extractASTInformation(
-      solcInput,
-      solcOutput,
-      "library"
-    );
+const createAST = ({ bre }) => {
+  const { astdocs }: { astdocs: ASTDocsBuidlerEnvironment } = bre;
+  const cachePath = bre.config.paths.cache;
+  const astDocDir = astdocs.path || cachePath;
 
-    const astDocsData = Object.keys(solcInput.sources)
-      .map(x => {
-        const imports = solcOutput.sources[x].ast.nodes
-          .filter(n => n.nodeType === "ImportDirective")
-          .map(n => n.absolutePath);
+  const solcInputPath = path.resolve(cachePath, SOLC_INPUT_FILENAME);
+  const solcOutputPath = path.resolve(cachePath, SOLC_OUTPUT_FILENAME);
 
-        return {
-          [x]: {
-            imports,
-            contracts: { ...contractInformation[x].contract },
-            interfaces: { ...interfaceInformation[x].interface },
-            libraries: { ...libraryInformation[x].library }
-          }
-        };
-      })
-      .reduce((acc, x) => {
-        return { ...acc, ...x };
-      }, {});
+  if (!fs.existsSync(solcInputPath)) {
+    throw new BuidlerPluginError("Cannot find solidity input source");
+  } else if (!fs.existsSync(solcOutputPath)) {
+    throw new BuidlerPluginError("Cannot find solidity output source");
+  }
+  const solcInput = require(solcInputPath);
+  const solcOutput = require(solcOutputPath);
 
-    // Write to file
-    if (!fs.existsSync(astDocDir)) {
-      fs.mkdirSync(astDocDir);
-    }
-    fs.writeFileSync(
-      path.resolve(astDocDir, "ast-docs.json"),
-      JSON.stringify(astDocsData, null, 4)
-    );
-  });
+  const contractInformation = extractASTInformation(
+    solcInput,
+    solcOutput,
+    "contract"
+  );
+  const interfaceInformation = extractASTInformation(
+    solcInput,
+    solcOutput,
+    "interface"
+  );
+  const libraryInformation = extractASTInformation(
+    solcInput,
+    solcOutput,
+    "library"
+  );
+
+  const astDocsData = Object.keys(solcInput.sources)
+    .filter(x => !astdocs.ignores || !x.includes(astdocs.ignores))
+    .map(x => {
+      const imports = solcOutput.sources[x].ast.nodes
+        .filter(n => n.nodeType === "ImportDirective")
+        .map(n => n.absolutePath);
+
+      return {
+        [x]: {
+          imports,
+          contracts: { ...contractInformation[x].contract },
+          interfaces: { ...interfaceInformation[x].interface },
+          libraries: { ...libraryInformation[x].library }
+        }
+      };
+    })
+    .reduce((acc, x) => {
+      return { ...acc, ...x };
+    }, {});
+
+  // Write to file
+  if (!fs.existsSync(astDocDir)) {
+    fs.mkdirSync(astDocDir);
+  }
+
+  fs.writeFileSync(
+    path.resolve(astDocDir, astdocs.file),
+    JSON.stringify(astDocsData, null, 4)
+  );
+}

--- a/test/buidler-project/buidler.config.js
+++ b/test/buidler-project/buidler.config.js
@@ -11,5 +11,10 @@ module.exports = {
     tests: "./test/contracts",
     artifacts: "./build/artifacts",
     cache: "./build/cache"
+  },
+  astdocs: {
+    path: "./build/ast",
+    file: "ast.json",
+    ignores: "ERC20"
   }
 };


### PR DESCRIPTION
- AST docs now included as a post-compile step
- Optional config options
    - `path`: path to output folder (uses cache by default)
   - `file`: name of ast file
   - `ignores`: simple string ignore.

Notes: 
1. I tinkered with making `ignores` a `RegExp` in the config but it seems the buidler is parsing it as an object but it's losing (cc @alcuadrado)
2. I had issues testing no configuration - something to do with how you `useEnvironment` in the tests is preventing the buidler lazy loading of config to work properly I suspect.