### PR TITLE
Upping to node 10, using mkdirSync recursive, logging when AST written

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,15 @@
     "LICENSE",
     "README.md"
   ],
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "devDependencies": {
     "@nomiclabs/buidler": "^1.0.1",
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^5.0.4",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^8.10.38",
+    "@types/node": "^10.17.24",
     "chai": "^4.2.0",
     "dotenv": "^6.2.0",
     "mocha": "^5.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export class ASTDocsBuidlerEnvironment {
     public readonly path: string = null,
     public readonly file: string = "ast-docs.json",
     public readonly ignores: string = ""
-  ) {}
+  ) { }
 }
 
 declare module "@nomiclabs/buidler/types" {
@@ -109,11 +109,12 @@ const createAST = ({ bre }) => {
 
   // Write to file
   if (!fs.existsSync(astDocDir)) {
-    fs.mkdirSync(astDocDir);
+    fs.mkdirSync(astDocDir, { recursive: true });
   }
 
   fs.writeFileSync(
     path.resolve(astDocDir, astdocs.file),
     JSON.stringify(astDocsData, null, 4)
   );
+  console.log("[buidler-ast-doc]: Wrote AST to", path.join(astDocDir, astdocs.file));
 };


### PR DESCRIPTION
- Upping to nodejs v10
- Using `mkdirSync` with `options` (requires node 10)
- Logs when AST created